### PR TITLE
Feature: Alternative Root Tenant Authority Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,3 +91,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Changed
 - Updated dependencies
+
+## [1.3.6] - 2022-09-19
+
+### Added
+- Ability to provide alternative root tenant authority via envvars

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Complete commands:
 git clone https://github.com/auth0-training/labs-vscode-extension.git
 cd labs-vscode-extension
 npm install
-vsce package
+npm run build:production
+npm run package
 code --install-extension release.vsix
 ```
 
@@ -49,7 +50,12 @@ Under the Debug Tab in Visual Studio Code, select `Run Extension`.
 
 ## Features
 ---
+## Alternative Root Tenant Authority
+If you are attempting to work on labs for Layer0 based cloud environments, you can tell the extension to use an alternate root tnenant by passing the following environment variables.
 
+- **VSCODE_EXTENSION_ISSUER** - Default:`https://auth0.auth0.com` The root tenant authority to use.
+- **AUTH0_VSCODE_EXTENSION_CLIENT_ID** - Default: `w94YV1qvYFMH2PnmFSIQVxkGJwk0tBGt` The client id that was created specifically for the extension with the altenrative root tenant authority.
+- **AUTH0_VSCODE_EXTENSION_AUDIENCE** - Default: `https://*.auth0.com/api/v2/` The Management API audience specific to your environment. **Note:** The wild card tenant segment is required. This enables the RTA to prompt the user for a specific tenant to authorize.
 ### Contributed Commands
 In addition to the visual features listed below, the Labs extension also contributes the following commands to the command palette:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-labs",
   "preview": true,
   "displayName": "Auth0 Labs",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "A Visual Studio Code extension for training lab automation and quick access to tenant information.",
   "main": "./dist/extension.js",
   "publisher": "auth0",

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,8 +1,24 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+const issuer =
+  process.env.AUTH0_VSCODE_EXTENSION_ISSUER || 'https://auth0.auth0.com';
+const client_id =
+  process.env.AUTH0_VSCODE_EXTENSION_CLIENT_ID ||
+  'w94YV1qvYFMH2PnmFSIQVxkGJwk0tBGt';
+const audience =
+  process.env.AUTH0_VSCODE_EXTENSION_AUDIENCE || 'https://*.auth0.com/api/v2/';
+const scope =
+  'openid offline_access read:client_grants delete:client_grants create:client_grants update:client_grants read:clients update:clients delete:clients create:clients read:client_keys update:client_keys delete:client_keys create:client_keys read:connections update:connections delete:connections create:connections read:resource_servers update:resource_servers delete:resource_servers create:resource_servers read:rules update:rules delete:rules create:rules read:hooks update:hooks delete:hooks create:hooks read:rules_configs update:rules_configs delete:rules_configs read:actions update:actions delete:actions read:email_provider update:email_provider delete:email_provider create:email_provider read:tenant_settings update:tenant_settings read:grants delete:grants read:guardian_factors update:guardian_factors read:mfa_policies update:mfa_policies read:email_templates create:email_templates update:email_templates read:roles update:roles delete:roles create:roles read:prompts update:prompts read:branding update:branding read:organizations update:organizations';
 
-export enum OIDC_CONFIG {
-  ISSUER = 'https://auth0.auth0.com',
-  CLIENT_ID = 'w94YV1qvYFMH2PnmFSIQVxkGJwk0tBGt',
-  AUDIENCE = 'https://*.auth0.com/api/v2/',
-  SCOPE = 'openid offline_access read:client_grants delete:client_grants create:client_grants update:client_grants read:clients update:clients delete:clients create:clients read:client_keys update:client_keys delete:client_keys create:client_keys read:connections update:connections delete:connections create:connections read:resource_servers update:resource_servers delete:resource_servers create:resource_servers read:rules update:rules delete:rules create:rules read:hooks update:hooks delete:hooks create:hooks read:rules_configs update:rules_configs delete:rules_configs read:actions update:actions delete:actions read:email_provider update:email_provider delete:email_provider create:email_provider read:tenant_settings update:tenant_settings read:grants delete:grants read:guardian_factors update:guardian_factors read:mfa_policies update:mfa_policies read:email_templates create:email_templates update:email_templates read:roles update:roles delete:roles create:roles read:prompts update:prompts read:branding update:branding read:organizations update:organizations',
+interface I_OIDC_CONFIG {
+  ISSUER: string;
+  CLIENT_ID: string;
+  AUDIENCE: string;
+  SCOPE: string;
 }
+
+export const OIDC_CONFIG: I_OIDC_CONFIG = {
+  ISSUER: issuer,
+  CLIENT_ID: client_id,
+  AUDIENCE: audience,
+  SCOPE: scope,
+};


### PR DESCRIPTION


### Description

This PR adds the ability to specify an alternative root tenant authority via environment variables. This allows the extension to authorize Layer0-based cloud deployments.


### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `main`
