### PR TITLE
Fix/codespaces support

### DIFF
--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,7 +1,7 @@
 export function getUrlForPort(port: number) {
   //if running in codespaces
   if (process.env['CODESPACES']) {
-    return `https://${process.env.CODESPACE_NAME}-${PORT}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`;
+    return `https://${process.env.CODESPACE_NAME}-${port}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`;
   }
   if (process.env['INSTANCE_ID']) {
     return `https://${port}-0-${process.env.INSTANCE_ID}.auth0-labs.appsembler.com`;

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,7 +1,7 @@
 export function getUrlForPort(port: number) {
   //if running in codespaces
   if (process.env['CODESPACES']) {
-    return `https://${process.env.CLOUDENV_ENVIRONMENT_ID}-${port}.apps.codespaces.githubusercontent.com`;
+    return `https://${process.env.CODESPACE_NAME}-${PORT}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`;
   }
   if (process.env['INSTANCE_ID']) {
     return `https://${port}-0-${process.env.INSTANCE_ID}.auth0-labs.appsembler.com`;


### PR DESCRIPTION
This is a fix to the that resolves the correct Codespaces App URL when using the `openEndpointByName` command in Codespaces. Fixes #35 

## Testing Instructions
1. Clone this repo to your local machine
2. Switch to the fix/codespaces-support branch and open this repo in VSCode
3. Build the project and extension (this will create a file called `release.vsix` in the project's root directory:
```
npm install
npm run build:production
npm run package
```
4. Fork an existing Auth0 lab (e.g. Create an Application) into your personal account 
5. Open the repo in Codespaces
6. Select the `Extensions` view in the right gutter
7. Click the three dots in the Extensions panel and select `Install from VSIX...`
8. Click `Show local`
9. Navigate to your local `release.vsix` file to install the extension
10. You'll be asked to refresh the project
11. Proceed with the lab as normal, and test that the link to the web app in the Codetour resolves to the correct Codespaces URL. 