### PR TITLE
Default Keyword Replacement Mapping Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,3 +140,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Changed
 - reverted to auth0 v2.42.0
+
+## [1.4.2] - 2023-04-19
+### Added
+- Support for Codespaces added so that when the registered command `openEndpointByName` is used, it resolves the correct URL for apps launched in the Codespaces environment.
+
+## [1.4.3] - 2023-05-01
+### Added
+- Implemented `auth0.lab.postConfigureCommand` command
+- Support for writing more than one app config to a single `.env` without overwriting values
+- Added runtime-specific replacement values for tenant configuration from yaml: `CODESPACE_NAME` (same as defined [here]( https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace)) and `AUTH0_DOMAIN` (your tenant domain). 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ In addition to the visual features listed below, the Labs extension also contrib
 - **Auth0: Configure Tenant Resources** - `auth0.lab.tenantConfigure` Configures tenant for the current lab materials. Only available when lab materials are present in workspace.
 - **Auth0: Export Tenant** - `auth0.exportTenant` Exports tenant configuration yml to the root directory. This exports everything and needs to be edited down for a lab. 
 - **Auth0: Open Endpoint Url** - `auth0.lab.openEndpointByName?["Endpoint 1, Endpoint 2"]` Opens the URL associated with a specific named endpoint in the default browser. Multiple endpoints can be opened by supplying a comma seperated list. Only available when lab materials are present in workspace.
+- **Auth0: Run Post Configure Command** `auth0.lab.postConfigureCommand` Allows you to specify the path of a shell script in `environment.json` (i.e., `"postConfigureCommand": "<script-path>"`), that will execute upon configuration completion. Enables you to run a script to perform actions like storing values client id and client secret as secrets in the environment. This command currently has access to the following environment variables:
+  - `AUTH0_DOMAIN`: Your Auth0 domain URI
+  - `AUTH0_TOKEN`: The access token issued to your client from the authorization server.
 
 ### Authenticating
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-labs",
   "preview": true,
   "displayName": "Auth0 Labs",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A Visual Studio Code extension for training lab automation and quick access to tenant information.",
   "main": "./dist/extension.js",
   "publisher": "auth0",

--- a/package.json
+++ b/package.json
@@ -226,6 +226,13 @@
       },
       {
         "category": "Auth0",
+        "command": "auth0.lab.postConfigureCommand",
+        "title": "Run Post Configure Command",
+        "icon": "$(beaker)",
+        "enablement": "auth0:authenticated && auth0:isLabWorkspace"
+      },
+      {
+        "category": "Auth0",
         "command": "auth0.lab.openLocalEndpoint",
         "title": "Open Url",
         "icon": "$(beaker)",

--- a/src/features/deploy/commands.ts
+++ b/src/features/deploy/commands.ts
@@ -71,6 +71,10 @@ export class DeployCommands {
           AUTH0_DOMAIN: getDomainFromToken(accessToken),
           AUTH0_CLIENT_ID: 'NEEDED FOR v7.17.0 Deploy CLI',
           AUTH0_ALLOW_DELETE: false,
+          AUTH0_KEYWORD_REPLACE_MAPPINGS: {
+            AUTH0_DOMAIN: getDomainFromToken(accessToken),
+            CODESPACE_NAME: process.env.CODESPACE_NAME
+          }
         }),
       };
       await deploy(opts);

--- a/src/features/labs/commands.ts
+++ b/src/features/labs/commands.ts
@@ -226,7 +226,9 @@ export class LabCommands {
       const terminal = window.createTerminal({
         name: 'Post Configure Script',
         env: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           AUTH0_DOMAIN: getDomainFromToken(accessToken),
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           AUTH0_TOKEN: accessToken,
         },
       });

--- a/src/features/labs/models.ts
+++ b/src/features/labs/models.ts
@@ -4,6 +4,7 @@ export interface LocalEnvironment {
   resources: string | null;
   unauthenticatedTour: string | null;
   postConfigureTour: string | null;
+  postConfigureCommand: string | null;
   clients: Array<Resource>;
   resourceServers: Array<Resource>;
 }

--- a/src/features/labs/writer.ts
+++ b/src/features/labs/writer.ts
@@ -6,7 +6,7 @@ const openTextDocument = vscode.workspace.openTextDocument;
 const fs = vscode.workspace.fs;
 
 export class LabEnvWriter {
-  constructor(private workspace: vscode.Uri) { }
+  constructor(private workspace: vscode.Uri) {}
 
   getExisting = async (uri: vscode.Uri) => {
     try {
@@ -15,43 +15,36 @@ export class LabEnvWriter {
 
       // read and parse file into name/value pairs
       return await readUriContents(uri)
-        .then(file => file.split('\n'))
-        .then(lines => lines.map(line => {
-          const pair = line.split('=');
-          return { name: pair[0], value: pair[1] };
-        }));
+        .then((file) => file.split('\n'))
+        .then((lines) =>
+          lines.map((line) => {
+            const pair = line.split('=');
+            return { name: pair[0], value: pair[1] };
+          })
+        );
     } catch {
       // return an empty array if file does not exist
       return [];
     }
-
-
   };
 
   writeAll = async (resolvers: Resolver[]) => {
-    resolvers.forEach(async (resolver) => {
+    for (const resolver of resolvers) {
       const uri = vscode.Uri.joinPath(
         this.workspace,
         resolver.getDirectory(),
         '.env'
       );
 
-
       const existingEnv = await this.getExisting(uri);
       const newEnv = resolver.resolveEnv(resolvers);
       const unique = [
-        ...new Map(
-          existingEnv.concat(newEnv).map(m => [m.name, m])
-        )
-          .values()
+        ...new Map(existingEnv.concat(newEnv).map((m) => [m.name, m])).values(),
       ];
 
-      const env = unique
-        .map((i) => `${i.name}=${i.value}`)
-        .join('\n');
-
+      const env = unique.map((i) => `${i.name}=${i.value}`).join('\n');
 
       await fs.writeFile(uri, Buffer.from(env, 'utf8'));
-    });
+    }
   };
 }

--- a/src/features/labs/writer.ts
+++ b/src/features/labs/writer.ts
@@ -1,23 +1,56 @@
 import * as vscode from 'vscode';
+import { readUriContents } from '../../utils';
 import { Resolver } from './resolver';
 
 const openTextDocument = vscode.workspace.openTextDocument;
 const fs = vscode.workspace.fs;
 
 export class LabEnvWriter {
-  constructor(private worspace: vscode.Uri) {}
+  constructor(private workspace: vscode.Uri) { }
+
+  getExisting = async (uri: vscode.Uri) => {
+    try {
+      // will error if file does not exist
+      const stat = await fs.stat(uri);
+
+      // read and parse file into name/value pairs
+      return await readUriContents(uri)
+        .then(file => file.split('\n'))
+        .then(lines => lines.map(line => {
+          const pair = line.split('=');
+          return { name: pair[0], value: pair[1] };
+        }));
+    } catch {
+      // return an empty array if file does not exist
+      return [];
+    }
+
+
+  }
 
   writeAll = async (resolvers: Resolver[]) => {
     resolvers.forEach(async (resolver) => {
       const uri = vscode.Uri.joinPath(
-        this.worspace,
+        this.workspace,
         resolver.getDirectory(),
         '.env'
       );
-      const env = resolver
-        .resolveEnv(resolvers)
+
+
+      const existingEnv = await this.getExisting(uri);
+      const newEnv = resolver.resolveEnv(resolvers)
+      const unique = [
+        ...new Map(
+          existingEnv.concat(newEnv).map(m => [m.name, m])
+        )
+          .values()
+      ];
+
+      const env = unique
         .map((i) => `${i.name}=${i.value}`)
-        .join('\n');
+        .join('\n')
+
+
       await fs.writeFile(uri, Buffer.from(env, 'utf8'));
     });
   };

--- a/src/features/labs/writer.ts
+++ b/src/features/labs/writer.ts
@@ -26,7 +26,7 @@ export class LabEnvWriter {
     }
 
 
-  }
+  };
 
   writeAll = async (resolvers: Resolver[]) => {
     resolvers.forEach(async (resolver) => {
@@ -38,7 +38,7 @@ export class LabEnvWriter {
 
 
       const existingEnv = await this.getExisting(uri);
-      const newEnv = resolver.resolveEnv(resolvers)
+      const newEnv = resolver.resolveEnv(resolvers);
       const unique = [
         ...new Map(
           existingEnv.concat(newEnv).map(m => [m.name, m])
@@ -48,7 +48,7 @@ export class LabEnvWriter {
 
       const env = unique
         .map((i) => `${i.name}=${i.value}`)
-        .join('\n')
+        .join('\n');
 
 
       await fs.writeFile(uri, Buffer.from(env, 'utf8'));

--- a/tests/suite/extension.test.ts
+++ b/tests/suite/extension.test.ts
@@ -15,5 +15,5 @@ suite('Extension', () => {
       await started.activate();
       assert.strictEqual(started && started.isActive, true);
     }
-  });
+  }).timeout(1000 * 10);//10 seconds
 });


### PR DESCRIPTION
### Description

This PR addresses a number of feature requests for running samples in GitHub Codespaces and advanced configuration use cases.

Fixes #45
Fixes #44 
Fixes #43 

### Testing

To test this change, you will need to run a lab in codespaces with a custom build of the extension.

1. open a lab repository in codespaces.
2. uninstall the auth0 labs extension from the running codespace
3. download the custom build associated with the pull request
4. uncompress the zip archive to gain access to the release.vsix file
5. on the extension pane, select the `...` menu and select **Install from VSIX**
6. click the show local button
7. select the release.vsix

You now have a custom install of the extension running in codespaces. 

#### Default Keyword Replacement Mapping

Update the tenant.yml for the lab to include the keyword replacements for `AUTH0_DOMAIN` and `CODESPACE_NAME`. Sign in to a tenant and click the configure button when prompted.

The deploy should be successful and you should see the appropriate values in your tenant and associated .env files.

#### Post Configuration Script

Update the environment.json for the lab to include a reference to a shell script. Create the shell script and echo out the values for `AUTH0_DOMAIN` and `AUTH0_TOKEN`.

Run the configure command and verify values are printed to console output.

#### Multiple Writes to Same .env File

Update the environment.josn for the lab to write two or more clients to the same directory.

Run the configure command and verify that all values are written to the .env file with no duplication.


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
