### PR TITLE
Add GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,8 +149,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 - Implemented `auth0.lab.postConfigureCommand` command
 - Support for writing more than one app config to a single `.env` without overwriting values
-- Added runtime-specific replacement values for tenant configuration from yaml: `CODESPACE_NAME` (same as defined [here]( https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace)) and `AUTH0_DOMAIN` (your tenant domain). 
+- Added environment-specific replacement values for tenant configuration from yaml: `CODESPACE_NAME` (same as defined [here]( https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace)) and `AUTH0_DOMAIN` (your tenant domain). 
 
 ## [1.4.4] - 2023-05-31
 ### Changed
 - Auth0 Training logo (branding)
+
+- ## [1.4.5] - 2023-08-18
+### Added
+- Added environment-specific replacement value for tenant configuration from yaml: `GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN` (same as defined [here]( https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Changed
 - Auth0 Training logo (branding)
 
-- ## [1.4.5] - 2023-08-18
+## [1.4.5] - 2023-08-18
 ### Added
 - Added environment-specific replacement value for tenant configuration from yaml: `GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN` (same as defined [here]( https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ In addition to the visual features listed below, the Labs extension also contrib
   - `AUTH0_DOMAIN`: Your Auth0 domain URI
   - `AUTH0_TOKEN`: The access token issued to your client from the authorization server.
 
+### Auth0 Deploy CLI Keyword Replacement
+This extension uses the Auth0 Deploy CLI, which makes it possible to leverage environment-specific [keyword replacement](https://auth0.com/docs/deploy-monitor/deploy-cli-tool/keyword-replacement) in resource files (e.g., yml and json). These are the current keywords supported:
+- `CODESPACE_NAME`: Returns the domain of the GitHub Codespaces forwarded port. For example, `app.github.dev` (when using a Codespaces environment)
+- `GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN`: Returns the name of the GitHub Codespace (when using a Codespaces environment)
+- `AUTH0_DOMAIN`: Your Auth0 domain URI
+
 ### Authenticating
 
 The first thing to do is connect to your Auth0 account.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-labs",
   "preview": true,
   "displayName": "Auth0 Labs",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "A Visual Studio Code extension for training lab automation and quick access to tenant information.",
   "main": "./dist/extension.js",
   "publisher": "auth0",

--- a/src/features/deploy/commands.ts
+++ b/src/features/deploy/commands.ts
@@ -73,7 +73,8 @@ export class DeployCommands {
           AUTH0_ALLOW_DELETE: false,
           AUTH0_KEYWORD_REPLACE_MAPPINGS: {
             AUTH0_DOMAIN: getDomainFromToken(accessToken),
-            CODESPACE_NAME: process.env.CODESPACE_NAME
+            CODESPACE_NAME: process.env.CODESPACE_NAME,
+            GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN: process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
           }
         }),
       };


### PR DESCRIPTION
Fixes #51 
## Testing Instructions

1. Build the extension using directions [here](https://oktawiki.atlassian.net/wiki/spaces/TE/pages/2811200140/Debugging+the+Auth0+Labs+Extension).

2. Update the `resources.yml` for the lab to include the keyword replacements for `GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN` in the Allowed Login and Callback URLs. 

3.  Sign in to a tenant and click the configure button when prompted.

4. The deploy should be successful and you should see the appropriate values in your tenant and associated `.env` files.