### PR TITLE
fix(security): run npm ci with --ignore-scripts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         node-version: '24'
     - name: Install Dependencies
-      run: npm ci
+      run: npm ci --ignore-scripts
     - name: Run Lint
       run: npm run lint
     - name: Run Tests (macOS & Windows)


### PR DESCRIPTION
This would avoid malicious scripts in vulnerable packages to be executed on CI